### PR TITLE
Fix non-terminating build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "webpack-dev-server --inline --progress --config build/webpack.local.js",
-    "build": "webpack --config build/webpack.local.js --mode development",
+    "build": "webpack --config build/webpack.dist.js --mode development",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Makimo",


### PR DESCRIPTION
The `npm run build` command was not properly terminating as it was using
the development webpack config which used the watch mode. The issue was
resolved by switching to distribution configuration for `npm run build`.