### PR TITLE
Improve elements sending in Designer, without sending XML

### DIFF
--- a/src/components/Geogebra/GeogebraViews.js
+++ b/src/components/Geogebra/GeogebraViews.js
@@ -62,6 +62,7 @@ export default class {
         this.log.debug('initListener');
 
         api.service('elements').on('created', (element) => {
+            this.log.debug('Created element', element.name, element.workshop);
             const pos = this.workshopIds.indexOf(element.workshop);
             if (pos !== -1) {
                 this.GAVs[pos].setElement(element);
@@ -69,6 +70,7 @@ export default class {
         });
 
         api.service('elements').on('patched', (element) => {
+            this.log.debug('Patched element', element.name, element.workshop);
             const pos = this.workshopIds.indexOf(element.workshop);
             if (pos !== -1) {
                 this.GAVs[pos].updateElementXML(element.name, element.xml);
@@ -76,6 +78,7 @@ export default class {
         });
 
         api.service('elements').on('removed', (element) => {
+            this.log.debug('Removed element', element.name, element.workshop);
             const pos = this.workshopIds.indexOf(element.workshop);
             if (pos !== -1) {
                 this.GAVs[pos].deleteObject(element.name);
@@ -83,6 +86,7 @@ export default class {
         });
 
         api.service('workshops').on('xml-changed', (workshop) => {
+            this.log.debug('Created workshop', workshop.name, workshop.id);
             const pos = this.workshopIds.indexOf(workshop.id);
             if (pos !== -1) {
                 this.GAVs[pos].setXML(workshop.xml);

--- a/src/components/Pages/Admin/Designer.vue
+++ b/src/components/Pages/Admin/Designer.vue
@@ -474,8 +474,8 @@ export default {
 
             for (let i = 0; i < groupsObjects.length; i += 1) {
                 const g = groupsObjects[i];
-                /* eslint-disable-next-line no-await-in-loop */
-                const promise = await this.createOrUpdateWorkshopWithElements(g._id, xml);
+
+                const promise = this.createOrUpdateWorkshopWithElements(g._id, xml);
                 promises.push(promise);
             }
 
@@ -504,8 +504,8 @@ export default {
 
             for (let i = 0; i < groupsObjects.length; i += 1) {
                 const g = groupsObjects[i];
-                /* eslint-disable-next-line no-await-in-loop */
-                const promise = await this.createOrUpdateWorkshopWithElements(g._id, xml);
+
+                const promise = this.createOrUpdateWorkshopWithElements(g._id, xml);
                 promises.push(promise);
             }
 
@@ -547,11 +547,12 @@ export default {
         },
 
         async addElements(groupId) {
+            const promises = [];
+
             for (let i = 0; i < this.GI.applet.getObjectNumber(); i += 1) {
                 const label = this.GI.applet.getObjectName(i);
 
-                /* eslint-disable-next-line no-await-in-loop */
-                await this.createElement({
+                const promise = this.createElement({
                     id: `${groupId}-${label}`,
                     name: label,
                     owner: null,
@@ -559,9 +560,12 @@ export default {
                     xml: this.GI.applet.getXML(label),
                     obj_cmd_str: this.GI.applet.getCommandString(label, false),
                 });
+                promises.push(promise);
 
                 this.$log.debug('createdElement', label);
             }
+
+            await Promise.all(promises);
         },
 
         async removeThenAddElements(groupId) {

--- a/src/components/Pages/Admin/Designer.vue
+++ b/src/components/Pages/Admin/Designer.vue
@@ -530,6 +530,8 @@ export default {
                 let correct = 0;
 
                 if (error.code === 400) {
+                    this.$log.debug('error code 400 ', error.message);
+
                     await this.removeThenAddElements(groupId);
 
                     // await this.updateWorkshop([groupId, { xml }]);
@@ -565,11 +567,11 @@ export default {
         async removeThenAddElements(groupId) {
             this.$log.debug('groupId', groupId);
 
-            await this.removeElement(null, {
+            await this.removeElement([null, {
                 query: {
                     workshop: groupId,
                 },
-            });
+            }]);
             this.$log.debug('groupId', groupId);
             await this.addElements(groupId);
         },


### PR DESCRIPTION
In all cases geogebra objects are sent through service('elements'), without XML. This improvement is connected to server fix enabling admin to listen to his own events, which are sent through the Designer and received in Admin View.