### PR TITLE
Fix group name populate MATHNETNG-145

### DIFF
--- a/src/components/Pages/Student/StudentGeogebra.vue
+++ b/src/components/Pages/Student/StudentGeogebra.vue
@@ -120,7 +120,7 @@ export default {
         },
     },
 
-    async reated() {
+    async created() {
         await this.getGroup(this.id);
         this.$store.commit('setStudentGroup', this.group);
         this.saveUserNumber();
@@ -159,8 +159,8 @@ export default {
     },
 
     async beforeDestroy() {
-        await this.leaveWorkshop();
         this.$store.commit('setStudentGroup', undefined);
+        await this.leaveWorkshop();
     },
 };
 </script>


### PR DESCRIPTION
1. Fix typo which blocked displaying Group name number
2. Change methods order in `beforeDestroy` hook to clear Group name number after logout.