### PR TITLE
Display group color over groups view in views section, add color for …

### DIFF
--- a/src/assets/styles/style.scss
+++ b/src/assets/styles/style.scss
@@ -308,3 +308,12 @@ table.designer-class-table tr {
         margin-top: 26px;
     }
 }
+
+.group-color {
+    height: 1em;
+    width: 3em;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 10px;
+    border-radius: 4px;
+}

--- a/src/components/Geogebra/GeogebraMergedAdminView.js
+++ b/src/components/Geogebra/GeogebraMergedAdminView.js
@@ -362,8 +362,11 @@ class GeogebraMergedAdminView {
             }
         }
 
+        const groupColor = this.getGroupColor(element.groupNum);
+
         this.evalXML(element.xml);
         this.evalCommand('UpdateConstruction()');
+        this.setDependentObjectsColor(element.name, groupColor);
         this.checkLock(element.name);
 
         this.ignoreUpdates = false;
@@ -386,6 +389,19 @@ class GeogebraMergedAdminView {
         });
 
         this.ignoreUpdates = false;
+    }
+
+    getGroupColor(groupNum) {
+        return this.params.groups[groupNum].color;
+    }
+
+    setDependentObjectsColor(label, color) {
+        const labelObject = this.applet.getObjectType(label);
+        const constructionTypes = ['segment', 'circle', 'ray', 'line', 'angle', 'triangle'];
+
+        if (constructionTypes.includes(labelObject)) {
+            this.setColor(label, color);
+        }
     }
 
     /**
@@ -506,6 +522,7 @@ class GeogebraMergedAdminView {
                     name: newLabel,
                     xml: newXML,
                     obj_cmd_str: newObjCmdStr,
+                    groupNum: groupNum,
                 }, additionalPoints,
             );
         } else {

--- a/src/components/Pages/Admin/View.vue
+++ b/src/components/Pages/Admin/View.vue
@@ -117,6 +117,7 @@
                         <div v-for="g in groupsInClass" :key="g._id"
                             class="admin-view-applet-holder">
                             <h3>{{ g.name }}</h3>
+                            <div class="group-color" :style="groupColor(g.color)"></div>
                             <div :id="getAppletId(g._id)" class="geogebra-applet">
                                 <!-- Geogebra Teacher's view applets -->
                             </div>
@@ -184,6 +185,10 @@ export default {
     },
 
     methods: {
+        groupColor(color) {
+            return(`background:rgb(${color})`);
+        },
+
         ...mapActions('classes', {
             findClasses: 'find',
         }),
@@ -272,6 +277,7 @@ export default {
                         // was obtained with ratio height/width = 2/3
                         width: ggbWidth,
                         height: ggbWidth * 9 / 16,
+                        groups: this.selectedGroups
                     },
                 );
             } else {


### PR DESCRIPTION
…constructions in merged view MATHNETNG-147

To test this PR we need to merge https://github.com/build3/MathNetServerV2/pull/40 or checkout on branch `feature/group-color`
1. Add color for groups, and display assigned color in view section
2. Assign group color for constructions in merged group view
