### PR TITLE
Fix missing colors after set live merge to on as default MATHNETNG-160

### DIFF
--- a/src/components/Geogebra/GeogebraViews.js
+++ b/src/components/Geogebra/GeogebraViews.js
@@ -113,8 +113,13 @@ export default class {
         this.mergedView.inject();
     }
 
+    liveMergeViews() {
+        this.mergedView.initializeCallbacks();
+    }
+
     mergeGoLive() {
         this.log.debug('Going live');
+        this.mergedView.clear();
         this.mergedView.initializeCallbacks();
         this.mergedView.loadWorkshops();
     }

--- a/src/components/Pages/Admin/View.vue
+++ b/src/components/Pages/Admin/View.vue
@@ -254,7 +254,7 @@ export default {
                     },
                 );
 
-                this.GeogebraViews.mergeGoLive();
+                this.GeogebraViews.liveMergeViews();
             } else {
                 this.showToast('Select groups for merged view', 'warning');
                 this.showMergedApplet = false;


### PR DESCRIPTION
## Description
This fix should resolve problem with constructions which not updating. This issue appeared after set live to on as default in merged view section.

## ISSUE
* [MATHNETNG-160](https://makimo.atlassian.net/browse/MATHNETNG-160)